### PR TITLE
Add gha using goreleaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Add build dependencies
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -cs)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $(lsb_release -cs)-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            gcc-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
+            pkg-config \
+            libsystemd-dev \
+            libsystemd-dev:arm64
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 *.deb
 exim_exporter
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+project_name: exim_exporter
+
+builds:
+  - ldflags: |
+      -X github.com/prometheus/common/version.Version={{.Version}}
+      -X github.com/prometheus/common/version.Revision={{.FullCommit}}
+      -X github.com/prometheus/common/version.Branch={{.Branch}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - systemd
+    env:
+      - CGO_ENABLED=1
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+          - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+# dockers:
+# - image_templates:
+#   - "gvengel/exim_exporter:{{ .Version }}"
+#   - "gvengel/exim_exporter:latest"
+#   dockerfile: Dockerfile
+#   use: buildx
+#   build_flag_templates:
+#   - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+#   - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+#   - "--label=org.opencontainers.image.url=https://github.com/gvengel/exim_exporter"
+#   - "--label=org.opencontainers.image.source=https://github.com/gvengel/exim_exporter"
+#   - "--label=org.opencontainers.image.version={{ .Version }}"
+#   - "--label=org.opencontainers.image.created={{.Date}}"
+#   - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+#   - "--label=org.opencontainers.image.licenses=MIT"
+
+# nfpms:
+#   - maintainer: Gabe Van Engel <gabe@schizoid.net>
+#     description: |-
+#       Prometheus exporter for the exim4 mail server.
+#       The exim exporter exports metrics from the exim4 mail
+#       server for consumption by prometheus.
+#     homepage: https://github.com/gvengel/exim_exporter
+#     license: MIT
+#     package_name: prometheus-exim_exporter
+#     formats:
+#       - deb
+#     depends:
+#       - exim4-config
+
+release:
+  prerelease: auto


### PR DESCRIPTION
Simplified build using go-releaser. 

* Builds both `ARM64` and `AMD64` releases.