### PR TITLE
Only run build on pushes to main or pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: build
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This prevents builds from running twice for pushes to pull requests.