### PR TITLE
Improve detection of daemon modes

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,6 +89,8 @@ var (
 var processFlags = map[string]string{
 	"-Mc": "delivering",
 	"-bd": "handling",
+	"-bdf": "handling",
+	"-q": "running",
 	"-qG": "running",
 }
 
@@ -190,7 +192,7 @@ func (e *Exporter) ProcessStates() map[string]float64 {
 			isDaemon := false
 			if p.leader {
 				for _, arg := range p.cmdline {
-					if arg == "-bd" {
+					if arg == "-bd" || arg == "-bdf" {
 						isDaemon = true
 					}
 				}


### PR DESCRIPTION
Recent exim versions on Debian and Ubuntu use `-bdf` for the main daemon instead of `-bd`.

Also handle a simple `-q` for queue runners when there is only a single queue.