### PR TITLE
Add new MsgId lenght for exim 4.97 updated spec

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,11 +87,11 @@ var (
 )
 
 var processFlags = map[string]string{
-	"-Mc": "delivering",
-	"-bd": "handling",
+	"-Mc":  "delivering",
+	"-bd":  "handling",
 	"-bdf": "handling",
-	"-q": "running",
-	"-qG": "running",
+	"-q":   "running",
+	"-qG":  "running",
 }
 
 type Process struct {
@@ -219,7 +219,7 @@ func (e *Exporter) CountMessages(dirname string) float64 {
 	}
 	var count float64
 	for _, name := range messages {
-		if len(name) == 18 && strings.HasSuffix(name, "-H") {
+		if (len(name) == 18 || len(name) == 25) && strings.HasSuffix(name, "-H") {
 			count += 1
 		}
 	}


### PR DESCRIPTION
Exim 4.97 has an updated message ID which is longer. The new code accepts both old and new lenghts

- The internal (but exposed in logs, Received: headers and Message-ID: headers)
    identifier used for messages is longer than in the previous release

https://lists.exim.org/lurker/message/20231104.135832.37148bbd.en.html